### PR TITLE
26 yaml config

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,38 +25,21 @@ module ApplicationHelper
     content_for(:canonical, tag(:link, :rel => :canonical, :href => url)) if url
   end
 
-  # Top level services and their children categories.
+  # General services and their children categories.
   # Displayed on the home page.
-  # @return [Array] Array of hashes with parent and children describing titles and list items.
+  # @return [Array] Array of category keywords.
   def service_terms
-    [
-      {
-        :parent => 'government assistance',
-        :children => ['CalFresh/Food Stamps','Health Insurance',
-          'WIC/Women, Infants, & Children',"SFMNP/Food vouchers for seniors",
-          'Medi-Cal','Medicare'].sort
-      },
-      {
-        :parent => "children, teens, & families",
-        :children => ['mentoring programs','discrimination','counseling',
-          'child care','abuse prevention','youth development'].sort
-      }
-    ]
+    terms = YAML.load(File.read(File.expand_path("#{Rails.root}/config/#{ Rails.env.test? ? 'test/' : '' }homepage_links.yml", __FILE__)))
+    terms['general']
   end
 
-  # Top level services and their children categories.
-  # Displayed on the home page.
-  # @return [Array] Array of hashes with parent and children describing titles and list items.
+  # Priority services and their children categories.
+  # Displayed on the home page in emphasized styling.
+  # @return [Array] Array of category keywords.
   def emergency_terms
-    [
-      { :parent => 'emergency',
-        :children => ['hotlines','emergency food','emergency shelter','Psychiatric emergency'].sort
-      },
-      { :parent => "reporting",
-        :children => ['domestic violence','child abuse'].sort
-      }
-    ]
-  end
+    terms = YAML.load(File.read(File.expand_path("#{Rails.root}/config/#{ Rails.env.test? ? 'test/' : '' }homepage_links.yml", __FILE__)))
+    terms['priority']
+ end
 
   # @return [Hash] Defines which query terms will display an info box
   # on the results page for select keywords.

--- a/app/views/home/_category_links.html.haml
+++ b/app/views/home/_category_links.html.haml
@@ -1,7 +1,8 @@
 %li
-  = service[:parent]
+  - # See config/homepage_links.yml for the source of the content that's filled in here.
+  = service[0]
   %ul
-    - service[:children].each do |child|
+    - Array(service[1]).each do |child|
       - child.include?("/") ? keyword = child.split("/").first : keyword = child
       %li
         %a{ :href => "/organizations?keyword=#{u keyword}", "data-gaq" => "['_trackEvent', 'Home_Categories', 'Click', '#{child}']" }

--- a/config/homepage_links.yml
+++ b/config/homepage_links.yml
@@ -1,0 +1,34 @@
+# These are the general links that appear on the homepage.
+# The top-level `general` text needs to stay, but all other
+# text can be edited to change what's shown on the homepage.
+general :
+  Government Assistance :
+    - CalFresh/Food Stamps
+    - Health Insurance
+    - Medi-Cal
+    - Medicare
+    - SFMNP/Food vouchers for seniors
+    - WIC/Women, Infants, & Children
+
+  Children, Teens, & Families :
+    - Abuse Prevention
+    - Child Care
+    - Counseling
+    - Discrimination
+    - Mentoring Programs
+    - Youth Development
+
+# These are the priority links that appear on the homepage,
+# which are styled with more emphasis than the general links.
+# The top-level `priority` text needs to stay, but all other
+# text can be edited to change what's shown on the homepage.
+priority :
+  Emergency :
+    - Psychiatric Emergency
+    - Emergency Food
+    - Emergency Shelter
+    - Hotlines
+
+  Reporting :
+    - Domestic Violence
+    - Child Abuse

--- a/config/test/homepage_links.yml
+++ b/config/test/homepage_links.yml
@@ -1,0 +1,15 @@
+# Please don't change this file unless you know what you're doing.
+# These values are needed in order for the tests to pass.
+general :
+  Government Assistance :
+    - CalFresh/Food Stamps
+    - Health Insurance
+    - Medi-Cal
+    - Medicare
+    - SFMNP/Food vouchers for seniors
+    - WIC/Women, Infants, & Children
+
+priority :
+  Reporting :
+    - Domestic Violence
+    - Child Abuse

--- a/spec/features/pages/homepage_spec.rb
+++ b/spec/features/pages/homepage_spec.rb
@@ -30,13 +30,13 @@ describe "Home page content elements" do
 
   it 'includes general-services category links' do
     within("#general-services") do
-      expect(page).to have_content "government assistance"
+      expect(page).to have_content "Government Assistance"
     end
   end
 
   it 'includes emergency-services category links' do
     within("#emergency-services") do
-      expect(page).to have_content "reporting"
+      expect(page).to have_content "Reporting"
     end
   end
 


### PR DESCRIPTION
Moves content for boxes of links displayed on the homepage to
/config/homepage_links.yml, so that the content is not in the
application_helper.

@monfresh ready for review and merge.
