### PR TITLE
Replace Memcache with Redis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,15 +29,10 @@ gem 'ohanakapa', '~> 1.1.1'
 gem 'faraday-http-cache', '~> 1.0'
 
 # Caching
-gem 'rack-cache', '~> 1.2'
-gem 'dalli', '~> 2.7.1'
-gem 'memcachier'
+gem 'redis-rack-cache', github: 'monfresh/redis-rack-cache', branch: 'readthis-compatibility'
 
 # Analytics
 gem 'newrelic_rpm', '>= 3.8.0.218'
-
-# Required for caching in production.
-gem 'kgio'
 
 # URL redirects.
 gem 'rack-rewrite', '~> 1.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: git://github.com/monfresh/redis-rack-cache.git
+  revision: 4a1323a010a722854cf93f499dbde073c859a48e
+  branch: readthis-compatibility
+  specs:
+    redis-rack-cache (1.2.2)
+      hiredis
+      rack-cache
+      readthis
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -70,6 +80,7 @@ GEM
       compass (~> 1.0.0)
       sass-rails (< 5.1)
       sprockets (< 2.13)
+    connection_pool (2.2.0)
     coveralls (0.8.2)
       json (~> 1.8)
       rest-client (>= 1.6.8, < 2)
@@ -78,7 +89,6 @@ GEM
       thor (~> 0.19.1)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
-    dalli (2.7.4)
     debug_inspector (0.0.2)
     derailed (0.1.0)
       derailed_benchmarks
@@ -146,6 +156,7 @@ GEM
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
     hike (1.2.3)
+    hiredis (0.6.0)
     html2haml (2.0.0)
       erubis (~> 2.7.0)
       haml (~> 4.0.0)
@@ -163,7 +174,6 @@ GEM
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
-    kgio (2.9.3)
     launchy (2.4.3)
       addressable (~> 2.3)
     letter_opener (1.4.1)
@@ -180,7 +190,6 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    memcachier (0.0.2)
     memoist (0.12.0)
     memory_profiler (0.9.4)
     mime-types (2.6.1)
@@ -238,6 +247,10 @@ GEM
     rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
+    readthis (0.7.0)
+      connection_pool (~> 2.1)
+      redis (~> 3.0)
+    redis (3.2.1)
     ref (2.0.0)
     requirejs-rails (0.9.5)
       railties (>= 3.1.1)
@@ -349,7 +362,6 @@ DEPENDENCIES
   capybara (~> 2.4.1)
   compass-rails
   coveralls
-  dalli (~> 2.7.1)
   derailed
   email_spec (~> 1.6.0)
   faraday-http-cache (~> 1.0)
@@ -361,19 +373,17 @@ DEPENDENCIES
   haml-rails
   jshint
   kaminari
-  kgio
   letter_opener
-  memcachier
   newrelic_rpm (>= 3.8.0.218)
   ohanakapa (~> 1.1.1)
   poltergeist
   puma
   quiet_assets
-  rack-cache (~> 1.2)
   rack-mini-profiler
   rack-rewrite (~> 1.5.0)
   rails_12factor
   railties (~> 4.2)
+  redis-rack-cache!
   requirejs-rails (= 0.9.5)
   rspec-rails (~> 3.1)
   rubocop

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,17 +15,24 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local = true
 
-  # Uncomment lines 22-28 below to test HTTP caching in development.
+  # Uncomment lines 22-35 below to test HTTP caching in development.
   # Visit the Wiki for more details:
   # https://github.com/codeforamerica/ohana-web-search/wiki/Improving-performance-with-caching
   #
   # config.action_controller.perform_caching = true
-  # config.cache_store = :dalli_store
-  # client = Dalli::Client.new
-  # config.action_dispatch.rack_cache = {
-  #   metastore: client,
-  #   entitystore: client
+
+  # config.cache_store = :readthis_store, ENV.fetch('REDISCLOUD_URL'), {
+  #   expires_in: 2.weeks.to_i,
+  #   namespace: 'cache'
   # }
+
+  # config.action_dispatch.rack_cache = {
+  #   metastore: "#{ENV.fetch('REDISCLOUD_URL')}/0/metastore",
+  #   entitystore: "#{ENV.fetch('REDISCLOUD_URL')}/0/entitystore",
+  #   use_native_ttl: true
+  # }
+
+  # config.static_cache_control = 'public, s-maxage=2592000, maxage=86400'
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,19 +65,17 @@ Rails.application.configure do
 
   config.action_controller.perform_caching = true
 
-  config.cache_store = :dalli_store
-  client = Dalli::Client.new((ENV['MEMCACHIER_SERVERS'] || '').split(','),
-                             username: ENV['MEMCACHIER_USERNAME'],
-                             password: ENV['MEMCACHIER_PASSWORD'],
-                             failover: true,
-                             socket_timeout: 1.5,
-                             socket_failure_delay: 0.2,
-                             value_max_bytes: 10_485_760)
-  config.action_dispatch.rack_cache = {
-    metastore:   client,
-    entitystore: client
+  config.cache_store = :readthis_store, ENV.fetch('REDISCLOUD_URL'), {
+    expires_in: 2.weeks.to_i,
+    namespace: 'cache'
   }
-  config.static_cache_control = 'public, max-age=2592000'
+
+  config.action_dispatch.rack_cache = {
+    metastore: "#{ENV.fetch('REDISCLOUD_URL')}/0/metastore",
+    entitystore: "#{ENV.fetch('REDISCLOUD_URL')}/0/entitystore",
+    use_native_ttl: true
+  }
+  config.static_cache_control = 'public, s-maxage=2592000, maxage=86400'
   # --------------------------------------------------------------------------
 
   # --------------------------------------------------------------------------

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -25,19 +25,17 @@ Rails.application.configure do
 
   config.action_controller.perform_caching = true
 
-  config.cache_store = :dalli_store
-  client = Dalli::Client.new((ENV['MEMCACHIER_SERVERS'] || '').split(','),
-                             username: ENV['MEMCACHIER_USERNAME'],
-                             password: ENV['MEMCACHIER_PASSWORD'],
-                             failover: true,
-                             socket_timeout: 1.5,
-                             socket_failure_delay: 0.2,
-                             value_max_bytes: 10_485_760)
-  config.action_dispatch.rack_cache = {
-    metastore:   client,
-    entitystore: client
+  config.cache_store = :readthis_store, ENV.fetch('REDISCLOUD_URL'), {
+    expires_in: 2.weeks.to_i,
+    namespace: 'cache'
   }
-  config.static_cache_control = 'public, max-age=2592000'
+
+  config.action_dispatch.rack_cache = {
+    metastore: "#{ENV.fetch('REDISCLOUD_URL')}/0/metastore",
+    entitystore: "#{ENV.fetch('REDISCLOUD_URL')}/0/entitystore",
+    use_native_ttl: true
+  }
+  config.static_cache_control = 'public, s-maxage=2592000, maxage=86400'
   # --------------------------------------------------------------------------
 
   # --------------------------------------------------------------------------

--- a/config/initializers/ohanapi.rb
+++ b/config/initializers/ohanapi.rb
@@ -1,7 +1,11 @@
-cache_store = ActiveSupport::Cache.lookup_store(:dalli_store)
+cache = Readthis::Cache.new(
+  ENV.fetch('REDISCLOUD_URL', 'redis://localhost:6379'),
+  driver: :hiredis,
+  expires_in: ENV.fetch('RRC_EXPIRES_IN', 300).to_i,
+  namespace: 'faraday')
 
 stack = Faraday::RackBuilder.new do |builder|
-  builder.use Faraday::HttpCache, store: cache_store, serializer: Marshal
+  builder.use Faraday::HttpCache, store: cache, serializer: Marshal
   builder.use Ohanakapa::Response::RaiseError
   builder.adapter Faraday.default_adapter
 end
@@ -10,5 +14,5 @@ Ohanakapa.configure do |config|
   config.api_token = ENV['OHANA_API_TOKEN'] if ENV['OHANA_API_TOKEN'].present?
   config.api_endpoint = ENV['OHANA_API_ENDPOINT']
 
-  config.middleware = stack
+  config.middleware = stack unless Rails.env.test?
 end


### PR DESCRIPTION
Why:

The new readthis gem, which works with Redis, is about 8x faster than dalli with memcached based on my tests with ApacheBench. Furthermore, with my fork of redis-rack-cache, we can specify when entries expire. Before, the cache would keep filling up and entries would never expire, which I'm pretty sure was the cause of the R14 memory errors on Heroku.