### PR TITLE
Remove link to ohanapi.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [SMC-Connect](http://www.smc-connect.org) is a Ruby on Rails app that makes it easy to find human services, farmers' markets, and other community organizations in San Mateo County, California.
 
-The app is powered by the [Ohana API](http://ohanapi.org) platform which was developed by [Code for America's 2013 San Mateo County, CA,](http://codeforamerica.org/2013-partners/san-mateo-county/) fellowship team: [@monfresh](https://github.com/monfresh), [@spara](https://github.com/spara), and [@anselmbradford](https://github.com/anselmbradford).
+The app is powered by the [Ohana API](https://github.com/codeforamerica/ohana-api) platform which was developed by [Code for America's 2013 San Mateo County, CA,](http://codeforamerica.org/2013-partners/san-mateo-county/) fellowship team: [@monfresh](https://github.com/monfresh), [@spara](https://github.com/spara), and [@anselmbradford](https://github.com/anselmbradford).
 
 In San Mateo County, there are two apps powered by Ohana: [SMC-Connect](http://smc-connect.org) and the [San Mateo County API](https://github.com/smcgov/ohana-api-smc) (that feeds the data to SMC-Connect). The API also comes with a built-in admin interface that allows organization members to update their own data. The updates are reflected in real-time on SMC-Connect.
 

--- a/app/views/component/about/_about.html.haml
+++ b/app/views/component/about/_about.html.haml
@@ -7,7 +7,7 @@
 
     %p
       This project is part of the development of the
-      = link_to('Ohana API', 'http://ohanapi.org', target: '_blank') + ','
+      = link_to('Ohana API', 'https://github.com/codeforamerica/ohana-api', target: '_blank') + ','
       an open source database of community services.
 
     %p

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -15,7 +15,5 @@
   %p.get-this-app
     %i.fa.fa-bullhorn
     %a{ href: 'https://github.com/codeforamerica/ohana-web-search' } Get this app
-    for your city or
-    #{link_to 'view project details', 'http://ohanapi.org'}.
-
+    for your city.
   #google-translate-container

--- a/spec/features/pages/homepage_spec.rb
+++ b/spec/features/pages/homepage_spec.rb
@@ -67,13 +67,6 @@ describe 'Home page footer elements' do
     end
   end
 
-  it 'includes a link to ohanapi.org' do
-    within('#app-footer') do
-      expect(find_link('view project details')[:href]).
-        to eq('http://ohanapi.org')
-    end
-  end
-
   it 'includes a link to codeforamerica.org' do
     within('#app-footer') do
       expect(find_link('Code for America')[:href]).


### PR DESCRIPTION
**Why**: The domain name registration expired and someone else bought it.