### PR TITLE
Update feedback popup

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,5 +143,7 @@ en:
     feedback:
       issue_link: 'File an issue on Github'
       issue_link_url: 'https://github.com/smcgov/SMC-Connect/issues'
-      submit_comment_label: 'Submit comments to the development team:'
+      submit_comment_label: >
+        Submit comments to the development team, or request your organization
+        be added to this directory:
 


### PR DESCRIPTION
**Why**: Edwin asked to add a note to let people know they can use the feedback form to request adding an organization to the website.