### PR TITLE
Allow app to be deployed to staging

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "name": "ohana-web-search-demo",
+  "name": "smc-connect",
   "scripts": {
   },
   "env": {
@@ -25,15 +25,6 @@
       "required": true
     },
     "OHANA_API_ENDPOINT": {
-      "required": true
-    },
-    "PATH": {
-      "required": true
-    },
-    "RACK_ENV": {
-      "required": true
-    },
-    "RAILS_ENV": {
       "required": true
     },
     "READTHIS_DRIVER": {

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -8,7 +8,7 @@ Rails.application.configure do
   # should set on your staging server. If you're deploying on Heroku, read this
   # article to learn how to set environment (also called config) variables:
   # https://devcenter.heroku.com/articles/config-vars
-  config.middleware.use '::Rack::Auth::Basic' do |u, p|
+  config.middleware.use ::Rack::Auth::Basic do |u, p|
     [u, p] == [ENV['STAGING_USER'], ENV['STAGING_PASSWORD']]
   end
 


### PR DESCRIPTION
Rails 5 expects class names for middleware, not strings or symbols.