### PR TITLE
Specify HTTPS for Google Translate script URL

### DIFF
--- a/app/javascript/app/util/translation/google-translate.js
+++ b/app/javascript/app/util/translation/google-translate.js
@@ -31,7 +31,7 @@ function init(layoutType) {
 
   // Add Google Translate script call by appending script element.
   var scriptElm = document.createElement('script');
-  var scriptUrl = '//translate.google.com/translate_a/element.js?cb=';
+  var scriptUrl = 'https://translate.google.com/translate_a/element.js?cb=';
   var scriptCallback = 'GoogleTranslate.googleTranslateElementInit';
   scriptElm.setAttribute('src', scriptUrl+scriptCallback);
   document.body.appendChild(scriptElm);


### PR DESCRIPTION
**Why**: Because we want HTTPS everywhere, and if we don’t specify it, it will use HTTP by default, and our CSP config does not allow HTTP.