### PR TITLE
Replace poltergeist with webdrivers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,12 +46,6 @@ jobs:
             - ~/.cache/yarn
 
       - run:
-          name: Install phantomjs
-          command: |
-            sudo curl --output /tmp/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1
-            sudo chmod ugo+x /tmp/phantomjs
-            sudo ln -sf /tmp/phantomjs /usr/local/bin/phantomjs
-      - run:
           name: Install Code Climate Test Reporter
           command: |
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,17 +12,6 @@ RUN apt-key add /tmp/yarn-pubkey.gpg && rm /tmp/yarn-pubkey.gpg
 RUN echo 'deb https://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list
 RUN apt-get update && apt-get install -y --no-install-recommends yarn
 
-# PhantomJS is required for running tests
-ENV PHANTOMJS_SHA256 86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f
-
-RUN mkdir /usr/local/phantomjs \
-  && curl -o phantomjs.tar.bz2 -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 \
-  && echo "$PHANTOMJS_SHA256 *phantomjs.tar.bz2" | sha256sum -c - \
-  && tar -xjf phantomjs.tar.bz2 -C /usr/local/phantomjs --strip-components=1 \
-  && rm phantomjs.tar.bz2
-
-RUN ln -s ../phantomjs/bin/phantomjs /usr/local/bin/
-
 WORKDIR /SMC-Connect
 
 COPY Gemfile /SMC-Connect

--- a/Gemfile
+++ b/Gemfile
@@ -42,11 +42,11 @@ group :test do
   gem 'capybara'
   gem 'email_spec'
   gem 'haml_lint'
-  gem 'poltergeist'
   gem 'rails-controller-testing'
   gem 'rubocop'
   gem 'simplecov', require: false
   gem 'vcr'
+  gem 'webdrivers'
   gem 'webmock', '~> 3.4'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,16 +56,17 @@ GEM
     bummr (0.5.0)
       rainbow
       thor
-    capybara (3.16.1)
+    capybara (3.21.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
-      regexp_parser (~> 1.2)
+      regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    childprocess (1.0.1)
+      rake (< 13.0)
     chunky_png (1.3.10)
-    cliver (0.3.2)
     codeclimate-engine-rb (0.4.1)
       virtus (~> 1.0)
     coderay (1.1.2)
@@ -205,7 +206,7 @@ GEM
     minitest (5.11.3)
     multi_json (1.13.1)
     multipart-post (2.0.0)
-    nokogiri (1.10.2)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     ohanakapa (1.1.3)
       sawyer (~> 0.8)
@@ -213,14 +214,10 @@ GEM
     parallel (1.16.2)
     parser (2.6.2.0)
       ast (~> 2.4.0)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     psych (3.1.0)
-    public_suffix (3.0.3)
+    public_suffix (3.1.0)
     puma (3.12.1)
-    rack (2.0.6)
+    rack (2.0.7)
     rack-cache (1.8.0)
       rack (>= 0.4)
     rack-mini-profiler (1.0.2)
@@ -260,7 +257,7 @@ GEM
       parser (>= 2.5.0.0, < 2.7, != 2.5.1.1)
       psych (~> 3.1.0)
       rainbow (>= 2.0, < 4.0)
-    regexp_parser (1.3.0)
+    regexp_parser (1.5.1)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -295,6 +292,7 @@ GEM
     ruby_dep (1.5.0)
     ruby_parser (3.9.0)
       sexp_processor (~> 4.1)
+    rubyzip (1.2.3)
     safe_yaml (1.0.4)
     sass (3.4.25)
     sass-rails (5.0.7)
@@ -306,6 +304,9 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
+    selenium-webdriver (3.142.3)
+      childprocess (>= 0.5, < 2.0)
+      rubyzip (~> 1.2, >= 1.2.2)
     sexp_processor (4.9.0)
     signet (0.11.0)
       addressable (~> 2.3)
@@ -353,6 +354,10 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
+    webdrivers (4.0.0)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -361,9 +366,6 @@ GEM
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
-    websocket-driver (0.7.0)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.18)
@@ -391,7 +393,6 @@ DEPENDENCIES
   kaminari-core
   letter_opener
   ohanakapa (~> 1.1.1)
-  poltergeist
   puma
   rack-mini-profiler
   rack-rewrite (~> 1.5.0)
@@ -411,6 +412,7 @@ DEPENDENCIES
   stackprof
   uglifier
   vcr
+  webdrivers
   webmock (~> 3.4)
   webpacker (~> 4.0)
   yard

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,7 +31,6 @@ packages installed on your computer:
 - Git
 - Ruby 2.3+
 - RVM (or other Ruby version manager)
-- PhantomJS
 - Yarn 0.25.2+
 - Node.js 6.0.0+
 
@@ -41,13 +40,12 @@ next step. Otherwise, there are two ways you can install the tools:
 - If you're on a Mac, the easiest way to install all the tools is to use
 @monfresh's [laptop] script.
 
-- Install everything manually: [Build tools], [Ruby with RVM], [phantomjs], and
+- Install everything manually: [Build tools], [Ruby with RVM], and
 [Node.js][node] (Linux only).
 
 [laptop]: https://github.com/monfresh/laptop
 [Build tools]: https://github.com/codeforamerica/howto/blob/master/Build-Tools.md
 [Ruby with RVM]: https://github.com/codeforamerica/howto/blob/master/Ruby.md
-[phantomjs]: https://github.com/jonleighton/poltergeist#installing-phantomjs
 [node]: https://github.com/codeforamerica/howto/blob/master/Node.js.md
 
 ### Install the dependencies and set the default environment variables:

--- a/spec/features/general/translate_spec.rb
+++ b/spec/features/general/translate_spec.rb
@@ -1,32 +1,11 @@
 require 'rails_helper'
 
 feature 'page translation', :js do
-  background do
-    page.driver.remove_cookie('googtrans')
-  end
-
-  context 'translation cookie is set to Spanish' do
-    it 'displays Spanish-language contents' do
-      page.driver.
-        set_cookie('googtrans', '/en/es', path: '/', domain: 'lvh.me')
-      page.driver.
-        set_cookie('googtrans', '/en/es', path: '/', domain: '.lvh.me')
-
-      visit("http://www.lvh.me:#{Capybara.server_port}/")
-      within('#language-box') do
-        all_links = all('a')
-        expect(all_links).not_to include 'Español'
-      end
-      expect(page).to have_content('Necesito')
-    end
-  end
-
   context 'homepage is translated' do
     it 'displays translated contents' do
       visit("http://www.lvh.me:#{Capybara.server_port}/")
       find_link('Español').click
       delay
-      expect(page.driver.cookies['googtrans'].value).to eq('/en/es')
       within('#language-box') do
         all_links = all('a')
         expect(all_links).not_to include 'Español'
@@ -47,20 +26,16 @@ feature 'page translation', :js do
   end
 
   context 'page is translated between languages' do
-    xit 'displays translated content for each language' do
+    it 'displays translated content for each language' do
       visit("http://www.lvh.me:#{Capybara.server_port}/")
       find_link('Español').click
       delay
-      expect(page.driver.cookies['googtrans'].value).to eq('/en/es')
       expect(page).to have_content('Necesito')
       find_link('Tagalog').click
       delay
-      expect(page.driver.cookies['googtrans'].value).to eq('/en/tl')
       expect(page).to have_content('Kailangan ko')
       find_link('English').click
       expect(page).to have_content('I need')
-      delay
-      expect(page.driver.cookies['googtrans'].value).to eq('/en/en')
     end
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,17 +1,23 @@
-require 'capybara/poltergeist'
+require 'webdrivers/chromedriver'
 
 Capybara.configure do |config|
-  config.javascript_driver = :poltergeist
   config.default_max_wait_time = 5
   config.always_include_port = true
 end
 
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(
-    app, js_errors: false, phantomjs_options: ['--ignore-ssl-errors=yes']
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w[headless disable-gpu] }
   )
+
+  Capybara::Selenium::Driver.new app,
+                                 browser: :chrome,
+                                 desired_capabilities: capabilities
 end
+Capybara.javascript_driver = :headless_chrome
 
 Capybara.add_selector(:rel) do
   xpath { |rel| ".//a[@rel='#{rel}']" }
 end
+
+Webdrivers.cache_time = 86_400

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -3,7 +3,7 @@ require 'vcr'
 
 VCR.configure do |config|
   config.configure_rspec_metadata!
-  config.ignore_hosts '127.0.0.1', 'localhost'
+  config.ignore_hosts '127.0.0.1', 'localhost', 'chromedriver.storage.googleapis.com'
   config.default_cassette_options = { record: :once }
   config.cassette_library_dir = 'spec/cassettes'
   config.hook_into :webmock


### PR DESCRIPTION
**Why**: PhantomJS has been discontinued and is no longer guaranteed
to work on recent versions of macOS. Webdrivers is the latest
recommended gem that supports various drivers for Selenium, such as
the popular chromedriver.