### PR TITLE
Turn on Action Dispatch Rails 6.0 default

### DIFF
--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -18,7 +18,7 @@ Rails.application.config.action_dispatch.use_cookies_with_metadata = true
 
 # Change the return value of `ActionDispatch::Response#content_type` to
 # Content-Type header without modification.
-# Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false
+Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false
 
 # Return false instead of self when enqueuing is aborted from a callback.
 # Rails.application.config.active_job.return_false_on_aborted_enqueue = true


### PR DESCRIPTION
This is a continuation of turning on Rails 6.0 defaults one by one.
