### PR TITLE
Don't force UTF-8

### DIFF
--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -7,7 +7,7 @@
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
 # Don't force requests from old versions of IE to be UTF-8 encoded.
-# Rails.application.config.action_view.default_enforce_utf8 = false
+Rails.application.config.action_view.default_enforce_utf8 = false
 
 # Embed purpose and expiry metadata inside signed and encrypted
 # cookies for increased security.

--- a/spec/cassettes/homepage_search/with_keyword_that_returns_no_results.yml
+++ b/spec/cassettes/homepage_search/with_keyword_that_returns_no_results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=asdfg&location=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=asdfg&location=
     body:
       encoding: US-ASCII
       string: ''
@@ -31,7 +31,7 @@ http_interactions:
       Etag:
       - '"e8f186293fd305dd40df04d591a38d19"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=asdfg&location=&page=0&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=asdfg&location=&page=0>;
         rel="last"
       X-Total-Count:
       - '0'

--- a/spec/cassettes/info_box/with_keyword_that_matches_synonym_from_custom_info_box.yml
+++ b/spec/cassettes/info_box/with_keyword_that_matches_synonym_from_custom_info_box.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=health%20care%20reform&location=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=health%20care%20reform&location=
     body:
       encoding: US-ASCII
       string: ''
@@ -31,7 +31,7 @@ http_interactions:
       Etag:
       - '"1b5744f6cd4195967c57df49b4c7f6c7"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=health+care+reform&location=&page=0&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=health+care+reform&location=&page=0>;
         rel="last"
       X-Total-Count:
       - '0'

--- a/spec/cassettes/kind_filter/when_checking_a_single_Kind_checkbox/restricts_results_to_those_with_a_matching_Kind.yml
+++ b/spec/cassettes/kind_filter/when_checking_a_single_Kind_checkbox/restricts_results_to_those_with_a_matching_Kind.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:41 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&kind%5B%5D=Arts&location=&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&kind%5B%5D=Arts&location=&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,7 +102,7 @@ http_interactions:
       Etag:
       - '"828d556eea2551b7226620b63c770e93"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&kind%5B%5D=Arts&location=&org_name=&page=0&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&kind%5B%5D=Arts&location=&org_name=&page=0>;
         rel="last"
       X-Total-Count:
       - '0'

--- a/spec/cassettes/kind_filter/when_checking_multiple_Kind_checkboxes/restricts_results_to_those_matching_either_Kind_options.yml
+++ b/spec/cassettes/kind_filter/when_checking_multiple_Kind_checkboxes/restricts_results_to_those_matching_either_Kind_options.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:41 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&kind%5B%5D=Arts&kind%5B%5D=Human%20Services&location=&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&kind%5B%5D=Arts&kind%5B%5D=Human%20Services&location=&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"953c5c807270fc39ed61ad11df945e52"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&kind%5B%5D=Arts&kind%5B%5D=Human+Services&location=&org_name=&page=130&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&kind%5B%5D=Arts&kind%5B%5D=Human+Services&location=&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&kind%5B%5D=Arts&kind%5B%5D=Human+Services&location=&org_name=&page=130>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&kind%5B%5D=Arts&kind%5B%5D=Human+Services&location=&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '130'

--- a/spec/cassettes/kind_filter/when_unchecking_then_checking_a_Kind_checkbox/restricts_results_to_those_matching_the_Kind_option.yml
+++ b/spec/cassettes/kind_filter/when_unchecking_then_checking_a_Kind_checkbox/restricts_results_to_those_matching_the_Kind_option.yml
@@ -62,7 +62,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:42 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -91,8 +91,8 @@ http_interactions:
       Etag:
       - '"c464f727ed8f9567e522a8adc6f024ef"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=&page=343&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=&page=343>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '343'
@@ -134,7 +134,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:42 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&kind%5B%5D=Entertainment&location=&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&kind%5B%5D=Entertainment&location=&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -163,7 +163,7 @@ http_interactions:
       Etag:
       - '"c0213d1297200c86f89efb5d4489a208"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&kind%5B%5D=Entertainment&location=&org_name=&page=0&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&kind%5B%5D=Entertainment&location=&org_name=&page=0>;
         rel="last"
       X-Total-Count:
       - '0'

--- a/spec/cassettes/page_translation/results_page_is_translated/displays_translated_contents.yml
+++ b/spec/cassettes/page_translation/results_page_is_translated/displays_translated_contents.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=
     body:
       encoding: US-ASCII
       string: ''
@@ -31,8 +31,8 @@ http_interactions:
       Etag:
       - '"c464f727ed8f9567e522a8adc6f024ef"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&page=343&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&page=343>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&page=2>;
         rel="next"
       X-Total-Count:
       - '343'

--- a/spec/cassettes/searching_from_results_page/allows_searching_for_a_location.yml
+++ b/spec/cassettes/searching_from_results_page/allows_searching_for_a_location.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:23 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=94403&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=94403&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"cf780f26968d2fa37f3f3a0341ff5e09"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=94403&org_name=&page=100&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=94403&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=94403&org_name=&page=100>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=94403&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '100'

--- a/spec/cassettes/searching_from_results_page/allows_searching_for_an_agency_name.yml
+++ b/spec/cassettes/searching_from_results_page/allows_searching_for_an_agency_name.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:23 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=samaritan&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=samaritan
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"95c22c7c2ffa12c43477692523f1768a"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=samaritan&page=2&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=samaritan&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=samaritan&page=2>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=samaritan&page=2>;
         rel="next"
       X-Total-Count:
       - '2'

--- a/spec/cassettes/searching_from_results_page/allows_searching_for_both_keyword_and_agency_name.yml
+++ b/spec/cassettes/searching_from_results_page/allows_searching_for_both_keyword_and_agency_name.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:23 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=clinic&location=&org_name=samaritan&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=clinic&location=&org_name=samaritan
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"65ad465abf423801bd656f8244187e05"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=clinic&location=&org_name=samaritan&page=2&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=clinic&location=&org_name=samaritan&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=clinic&location=&org_name=samaritan&page=2>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=clinic&location=&org_name=samaritan&page=2>;
         rel="next"
       X-Total-Count:
       - '2'

--- a/spec/cassettes/searching_from_results_page/allows_searching_for_both_keyword_and_location.yml
+++ b/spec/cassettes/searching_from_results_page/allows_searching_for_both_keyword_and_location.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:24 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=clinic&location=94403&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=clinic&location=94403&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"96f1f64f007bc9baa6163ff182f32a80"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=clinic&location=94403&org_name=&page=11&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=clinic&location=94403&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=clinic&location=94403&org_name=&page=11>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=clinic&location=94403&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '11'

--- a/spec/cassettes/searching_from_results_page/allows_searching_for_both_location_and_agency_name.yml
+++ b/spec/cassettes/searching_from_results_page/allows_searching_for_both_location_and_agency_name.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:24 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=94403&org_name=samaritan&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=94403&org_name=samaritan
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/searching_from_results_page/allows_searching_for_keyword_location_and_agency_name.yml
+++ b/spec/cassettes/searching_from_results_page/allows_searching_for_keyword_location_and_agency_name.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:22 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=clinic&location=94403&org_name=samaritan&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=clinic&location=94403&org_name=samaritan
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/searching_from_results_page/when_clicking_organization_link_in_results/displays_locations_that_belong_to_that_organization.yml
+++ b/spec/cassettes/searching_from_results_page/when_clicking_organization_link_in_results/displays_locations_that_belong_to_that_organization.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:33 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=Samaritan%20House&location=&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=Samaritan%20House&location=&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"8fcd9dec58e38eaeff1269e75aa2bf55"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=Samaritan+House&location=&org_name=&page=3&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=Samaritan+House&location=&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=Samaritan+House&location=&org_name=&page=3>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=Samaritan+House&location=&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '3'

--- a/spec/cassettes/searching_from_results_page/when_clicking_the_clear_button_for_agency/clears_the_contents_of_the_agency_field.yml
+++ b/spec/cassettes/searching_from_results_page/when_clicking_the_clear_button_for_agency/clears_the_contents_of_the_agency_field.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:30 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=samaritan&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=samaritan
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"95c22c7c2ffa12c43477692523f1768a"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=samaritan&page=2&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=samaritan&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=samaritan&page=2>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=samaritan&page=2>;
         rel="next"
       X-Total-Count:
       - '2'

--- a/spec/cassettes/searching_from_results_page/when_clicking_the_clear_button_for_keyword/clears_the_contents_of_the_keyword_field.yml
+++ b/spec/cassettes/searching_from_results_page/when_clicking_the_clear_button_for_keyword/clears_the_contents_of_the_keyword_field.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:24 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=clinic&location=&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=clinic&location=&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"1e0538ca679185c161eae92bbba6cdbc"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=clinic&location=&org_name=&page=42&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=clinic&location=&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=clinic&location=&org_name=&page=42>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=clinic&location=&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '42'

--- a/spec/cassettes/searching_from_results_page/when_clicking_the_clear_button_for_location/clears_the_contents_of_the_location_field.yml
+++ b/spec/cassettes/searching_from_results_page/when_clicking_the_clear_button_for_location/clears_the_contents_of_the_location_field.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:32 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=94403&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=94403&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"cf780f26968d2fa37f3f3a0341ff5e09"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=94403&org_name=&page=100&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=94403&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=94403&org_name=&page=100>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=94403&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '100'

--- a/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_accreditation_list.yml
+++ b/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_accreditation_list.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:26 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_alternative_name.yml
+++ b/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_alternative_name.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:26 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_email_address.yml
+++ b/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_email_address.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:27 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_incorporation_date.yml
+++ b/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_incorporation_date.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:26 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_licenses_list.yml
+++ b/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_licenses_list.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:25 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_name_in_detail_box.yml
+++ b/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_name_in_detail_box.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:25 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_website_address.yml
+++ b/spec/cassettes/searching_from_results_page/when_organization_detail_box_is_shown/displays_organization_website_address.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:25 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=Example%20Agency
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/searching_from_results_page/when_search_returns_no_results/displays_a_helpful_error_message.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_no_results/displays_a_helpful_error_message.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:30 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=22031&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=22031&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,7 +102,7 @@ http_interactions:
       Etag:
       - '"038955ceaabdb4259582bd1bd5f0efce"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=22031&org_name=&page=0&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=22031&org_name=&page=0>;
         rel="last"
       X-Total-Count:
       - '0'

--- a/spec/cassettes/searching_from_results_page/when_search_returns_no_results/does_not_include_the_map_canvas.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_no_results/does_not_include_the_map_canvas.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:31 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=22031&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=22031&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,7 +102,7 @@ http_interactions:
       Etag:
       - '"038955ceaabdb4259582bd1bd5f0efce"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=22031&org_name=&page=0&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=22031&org_name=&page=0>;
         rel="last"
       X-Total-Count:
       - '0'

--- a/spec/cassettes/searching_from_results_page/when_search_returns_no_results/includes_the_homepage_links.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_no_results/includes_the_homepage_links.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:31 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=22031&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=22031&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,7 +102,7 @@ http_interactions:
       Etag:
       - '"038955ceaabdb4259582bd1bd5f0efce"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=22031&org_name=&page=0&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=22031&org_name=&page=0>;
         rel="last"
       X-Total-Count:
       - '0'

--- a/spec/cassettes/searching_from_results_page/when_search_returns_no_results/includes_the_no-results_selector.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_no_results/includes_the_no-results_selector.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:31 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=22031&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=22031&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,7 +102,7 @@ http_interactions:
       Etag:
       - '"038955ceaabdb4259582bd1bd5f0efce"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=22031&org_name=&page=0&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=22031&org_name=&page=0>;
         rel="last"
       X-Total-Count:
       - '0'

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_phone_extension.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_phone_extension.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:29 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"f28dcfba0282e74991cfbc4fcd8daa3c"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '2'

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_phone_number.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_phone_number.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:28 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"f28dcfba0282e74991cfbc4fcd8daa3c"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '2'

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_physical_address.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_physical_address.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:28 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"f28dcfba0282e74991cfbc4fcd8daa3c"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '2'

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_short_description.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_location_short_description.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:28 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"f28dcfba0282e74991cfbc4fcd8daa3c"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '2'

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_name_of_the_agency_as_a_link.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_name_of_the_agency_as_a_link.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:27 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"f28dcfba0282e74991cfbc4fcd8daa3c"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '2'

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_name_of_the_location_as_a_link.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_name_of_the_location_as_a_link.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:29 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"f28dcfba0282e74991cfbc4fcd8daa3c"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '2'

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_number_of_results.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/displays_the_number_of_results.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:28 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"f28dcfba0282e74991cfbc4fcd8daa3c"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '2'

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/includes_the_results_info_in_the_page_title.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/includes_the_results_info_in_the_page_title.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:29 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"f28dcfba0282e74991cfbc4fcd8daa3c"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '2'

--- a/spec/cassettes/searching_from_results_page/when_search_returns_results/populates_the_keyword_field_with_the_search_term.yml
+++ b/spec/cassettes/searching_from_results_page/when_search_returns_results/populates_the_keyword_field_with_the_search_term.yml
@@ -73,7 +73,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:30 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=lorem&location=&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -102,8 +102,8 @@ http_interactions:
       Etag:
       - '"f28dcfba0282e74991cfbc4fcd8daa3c"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=lorem&location=&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '2'

--- a/spec/cassettes/service_area_filter/when_entering_a_search_term_from_the_homepage/automatically_sets_service_area_smc.yml
+++ b/spec/cassettes/service_area_filter/when_entering_a_search_term_from_the_homepage/automatically_sets_service_area_smc.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=food&location=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=food&location=
     body:
       encoding: US-ASCII
       string: ''
@@ -31,8 +31,8 @@ http_interactions:
       Etag:
       - '"76bcb1fd532645b134beb380149a9344"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=food&location=&page=33&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=food&location=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=food&location=&page=33>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=food&location=&page=2>;
         rel="next"
       X-Total-Count:
       - '33'

--- a/spec/cassettes/service_area_filter/when_entering_a_search_term_from_the_homepage/does_not_automatically_set_service_area_smc.yml
+++ b/spec/cassettes/service_area_filter/when_entering_a_search_term_from_the_homepage/does_not_automatically_set_service_area_smc.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=food&location=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=food&location=
     body:
       encoding: US-ASCII
       string: ''
@@ -31,8 +31,8 @@ http_interactions:
       Etag:
       - '"76bcb1fd532645b134beb380149a9344"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=food&location=&page=33&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=food&location=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=food&location=&page=33>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=food&location=&page=2>;
         rel="next"
       X-Total-Count:
       - '33'

--- a/spec/cassettes/service_area_filter/when_unchecking_the_service_area_checkbox/includes_all_service_areas.yml
+++ b/spec/cassettes/service_area_filter/when_unchecking_the_service_area_checkbox/includes_all_service_areas.yml
@@ -89,7 +89,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:40 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -118,8 +118,8 @@ http_interactions:
       Etag:
       - '"c464f727ed8f9567e522a8adc6f024ef"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=&page=343&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=&page=343>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '343'

--- a/spec/cassettes/service_area_filter/when_unchecking_then_checking_service_area_checkbox/restricts_service_areas.yml
+++ b/spec/cassettes/service_area_filter/when_unchecking_then_checking_service_area_checkbox/restricts_service_areas.yml
@@ -89,7 +89,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:40 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=
     body:
       encoding: US-ASCII
       string: ''
@@ -118,8 +118,8 @@ http_interactions:
       Etag:
       - '"c464f727ed8f9567e522a8adc6f024ef"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=&page=343&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=&page=2&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=&page=343>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=&page=2>;
         rel="next"
       X-Total-Count:
       - '343'
@@ -161,7 +161,7 @@ http_interactions:
   recorded_at: Sat, 15 Aug 2015 18:04:40 GMT
 - request:
     method: get
-    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=&service_area=smc&utf8=%E2%9C%93
+    uri: http://smc-ohana-api-test.herokuapp.com/api/search?action=index&controller=locations&keyword=&location=&org_name=&service_area=smc
     body:
       encoding: US-ASCII
       string: ''
@@ -190,8 +190,8 @@ http_interactions:
       Etag:
       - '"2096078ee0f88384d33ecd04cb021fd3"'
       Link:
-      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=&page=271&service_area=smc&utf8=%E2%9C%93>;
-        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=&page=2&service_area=smc&utf8=%E2%9C%93>;
+      - <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=&page=271&service_area=smc>;
+        rel="last", <http://smc-ohana-api-test.herokuapp.com/api/search?keyword=&location=&org_name=&page=2&service_area=smc>;
         rel="next"
       X-Total-Count:
       - '271'

--- a/spec/features/search/results_page_search_spec.rb
+++ b/spec/features/search/results_page_search_spec.rb
@@ -13,7 +13,7 @@ feature 'searching from results page', :vcr do
     it 'displays the name of the location as a link' do
       location_url = '/locations/example-agency/' \
                      'example-location?keyword=lorem&' \
-                     'location=&org_name=&utf8=%E2%9C%93'
+                     'location=&org_name='
       expect(page).to have_link('Example Location', href: location_url)
     end
 


### PR DESCRIPTION
This is the last Rails 6.0 default to turn on.
This required updating the VCR cassettes to remove the utf8 parameter that is no longer being forced.
