### PR TITLE
Raise mail delivery errors

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -99,7 +99,7 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default charset: 'utf-8'
 
   config.action_mailer.smtp_settings = {

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
 
   # Ignore bad email addresses and do not raise email delivery errors.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default charset: 'utf-8'
 
   config.action_mailer.smtp_settings = {


### PR DESCRIPTION
I don't think sending email is working, but I'm not seeing any errors in the logs. Turning on errors should hopefully show that Sendgrid is not working.
