### PR TITLE
Use correct Sendgrid setup

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,8 +105,8 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     port: '587',
     address: 'smtp.sendgrid.net',
-    user_name: ENV.fetch('SENDGRID_USERNAME', nil),
-    password: ENV.fetch('SENDGRID_PASSWORD', nil),
+    user_name: 'apikey',
+    password: ENV['SENDGRID_API_KEY'],
     domain: 'heroku.com',
     authentication: :plain,
     enable_starttls_auto: true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -59,8 +59,8 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     port: '587',
     address: 'smtp.sendgrid.net',
-    user_name: ENV.fetch('SENDGRID_USERNAME', nil),
-    password: ENV.fetch('SENDGRID_PASSWORD', nil),
+    user_name: 'apikey',
+    password: ENV['SENDGRID_API_KEY'],
     domain: 'heroku.com',
     authentication: :plain,
     enable_starttls_auto: true


### PR DESCRIPTION
Sendgrid now uses an API key. This is the same change as the one I made for the ohana-api-smc app.
