### PR TITLE
Show Google logo on maps

### DIFF
--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -251,14 +251,6 @@ ul {
 // the search box in the middle of the screen and laying out the search box and
 // content as a two column layout on inside pages.
 
-.main {
-  * {
-    // Prevent popup overlap.
-    position: relative;
-  }
-}
-
-
 // Only used on /about route when JS is disabled.
 .about .close-button {
   display: none;

--- a/app/assets/stylesheets/_mixins.scss
+++ b/app/assets/stylesheets/_mixins.scss
@@ -165,6 +165,9 @@
 
   .toggle-group
   {
+    * {
+      position: relative;
+    }
     display: table-row;
     cursor: pointer;
 


### PR DESCRIPTION
I got an email from the Google Maps API Compliance team saying smc-connect.org was non-compliant because the maps aren't displaying the logo.

After some debugging, it turns out we weren't doing it on purpose. There was a CSS styling applied to the "main" class that made that part of the map disappear.

Disabling that position setting then caused the filter checkboxes to disappear. So I moved that setting to just the "toggle-group" class and now everything looks great.
