### PR TITLE
Remove feedback form

### DIFF
--- a/app/views/component/about/_feedback.html.haml
+++ b/app/views/component/about/_feedback.html.haml
@@ -5,21 +5,4 @@
       Want to get in touch?
     %p
       = link_to t('views.feedback.issue_link'), t('views.feedback.issue_link_url'), target: '_blank', rel: 'noopener'
-
-    %section.feedback-form
-      = form_tag('/feedback', method: :post) do
-        %p
-          = label_tag 'message', t('views.feedback.submit_comment_label')
-          = text_area_tag('message',
-                          nil,
-                          placeholder: 'enter your comment, question, etc.',
-                          rows: '4',
-                          required: 'true',
-                          class: 'comment')
-        %p
-          = label_tag 'from', 'Email:'
-          = email_field_tag 'from', nil, placeholder: 'your email address (optional)', class: 'email'
-          = hidden_field_tag 'agent', user_agent
-          = recaptcha_tags nonce: true
-        %p
-          = button_tag 'Send!', class: 'button-feedback-send'
+      = t('views.feedback.submit_comment_label')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,5 +145,5 @@ en:
       issue_link: 'File an issue on GitHub'
       issue_link_url: 'https://github.com/smcgov/SMC-Connect/issues'
       submit_comment_label: >
-        Submit comments to the development team, or request your organization
-        be added to this directory:
+        to submit comments to the development team, or request your organization
+        be added to this directory.

--- a/spec/features/pages/pages_spec.rb
+++ b/spec/features/pages/pages_spec.rb
@@ -8,7 +8,7 @@ feature 'Site Pages' do
     expect(page).to have_content 'Anselm Bradford'
     expect(page).to have_content 'Moncef Belyamani'
     expect(page).to have_content 'Sophia Parafina'
-    expect(page).to have_selector '#feedback-box .feedback-form'
+    expect(page).to have_selector '#feedback-box'
   end
 
   scenario 'when visiting results page directly', :vcr do


### PR DESCRIPTION
Too much spam lately. Instead, we'll leave the link to GitHub so people can submit issues or suggestions there.