### PR TITLE
Fix redirect to back error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,20 +16,10 @@ class ApplicationController < ActionController::Base
   end
 
   def render_bad_search
-    redirect_to path, error: t('errors.bad_search')
+    redirect_back(fallback_location: root_path, error: t('errors.bad_search'))
   end
 
   def render_not_found
-    redirect_to path, error: t('errors.not_found')
-  end
-
-  def path
-    referer = request.env['HTTP_REFERER']
-    uri = request.env['REQUEST_URI']
-    if referer.present? && referer != uri
-      :back
-    else
-      root_path
-    end
+    redirect_back(fallback_location: root_path, error: t('errors.not_found'))
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -43,4 +43,58 @@ describe ApplicationController do
 
     it_behaves_like 'redirects and displays alert'
   end
+
+  context 'when Ohanakapa::NotFound is raised' do
+    controller do
+      def index
+        raise Ohanakapa::NotFound, nil, nil
+      end
+    end
+
+    it 'redirects to root_path' do
+      get :index
+      expect(response).to redirect_to root_path
+    end
+
+    it 'displays a helpful message to the user' do
+      get :index
+      expect(flash[:error]).
+        to include('Sorry, that page does not exist. Please try a new search.')
+    end
+
+    it 'redirects to previous page if a referer exists' do
+      request.env['HTTP_REFERER'] = 'http://localhost:3000/about'
+
+      get :index
+
+      expect(response).to redirect_to 'http://localhost:3000/about'
+    end
+  end
+
+  context 'when Ohanakapa::BadRequest is raised' do
+    controller do
+      def index
+        raise Ohanakapa::BadRequest, nil, nil
+      end
+    end
+
+    it 'redirects to root_path' do
+      get :index
+      expect(response).to redirect_to root_path
+    end
+
+    it 'displays a helpful message to the user' do
+      get :index
+      expect(flash[:error]).
+        to include('That search was improperly formatted. Please try a new search.')
+    end
+
+    it 'redirects to previous page if a referer exists' do
+      request.env['HTTP_REFERER'] = 'http://localhost:3000/about'
+
+      get :index
+
+      expect(response).to redirect_to 'http://localhost:3000/about'
+    end
+  end
 end


### PR DESCRIPTION
`redirect_to :back` doesn't work anymore in Rails 6. Instead, we can use `redirect_back` with the root as the fallback location.
